### PR TITLE
Add README to docs: OctoAcme Project Management processes summary & index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme Program & Project Management Process Documentation Repo.
+
+## Overview of Project Management Processes
+
+OctoAcme employs an end-to-end project lifecycle that enables agile, cross-functional teamwork focused on customer value and iterative delivery. Projects begin with Project Initiation: defining the business need, aligning stakeholders, and setting initial objectives and acceptance criteria. Detailed Planning follows, using prioritized backlogs, scope estimation, work breakdown, and release mapping to drive actionable work.
+
+Execution & Tracking uses regular cadences (daily standups, sprint reviews/demos), structured boards, and task-level tracking. Quality is reinforced through peer code reviews, automated CI/CD tests, manual test plans where required, and a clear Definition of Done for work items. Risks are managed in a shared risk register with owners and escalation paths; communication cadences and decision logs keep stakeholders aligned.
+
+Release & Deployment follow staged environments and release checklists that include quality gates, rollback plans, and stakeholder notifications. After delivery, Retrospectives capture learnings and convert them into concrete action items for continuous improvement. Roles and personas (Project Manager, Product Owner / Stakeholder, Engineering & Design leads, QA/Test leads, Release/Operations owner) are explicitly defined to ensure clear ownership and effective handoffs across the lifecycle.
+
+Explore the detailed guides below for templates, checklists, and actionable tips on each phase of project management at OctoAcme.
+
+## Process Docs Index
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risks & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+> Keep this README up to date as docs evolve. Report gaps or improvement ideas via the process doc issue templates in .github/ISSUE_TEMPLATE/.


### PR DESCRIPTION
Adds docs/README.md as an entry point for OctoAcme Project Management documentation.
Includes a summarized overview of OctoAcme’s project management lifecycle, roles, communication, and QA practices.
Indexes and links all major process files for easy discovery and onboarding.
Closes: Closes https://github.com/itsrkator/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2